### PR TITLE
ci: split release workflow and bump dependencies

### DIFF
--- a/.github/workflows/release-wpf-app.yml
+++ b/.github/workflows/release-wpf-app.yml
@@ -1,7 +1,12 @@
-name: Build NWN Log Rotator
+name: Release NWN Log Rotator
 
 on:
-  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
 
 jobs:
   build:
@@ -69,3 +74,59 @@ jobs:
         name: Release-build-x64
         path: |
           bin/Release/x64/NWNLogRotator-x64.exe
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+    # Step 1: Checkout the repository
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    # Step 2: Download the build artifacts (x86 and x64)
+    - name: Download build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: Release-build-x86
+        path: ./bin/Release/x86/
+
+    - name: Download build artifacts (x64)
+      uses: actions/download-artifact@v4
+      with:
+        name: Release-build-x64
+        path: ./bin/Release/x64/
+
+    # Debugging Step: List all downloaded files (Linux)
+    - name: List all downloaded files
+      run: |
+        echo "Listing all downloaded files in x86 directory"
+        find ./bin/Release/x86/ -type f
+        echo "Listing all downloaded files in x64 directory"
+        find ./bin/Release/x64/ -type f
+
+    # Step 3: Determine the next semantic version tag
+    - name: Calculate next version
+      id: next_version
+      run: |
+        # Fetch all tags to ensure git describe works properly
+        git fetch --tags
+        # Get the latest tag, or default to v1.0.0 if none exists
+        latest_tag=$(git describe --tags $(git rev-list --tags --max-count=1) || echo "v1.0.0")
+        echo "Latest tag: $latest_tag"
+        # Calculate the next version
+        next_version=$(echo $latest_tag | awk -F. -v OFS=. '{$NF+=1; print}')
+        echo "next_version=$next_version" >> $GITHUB_ENV
+
+    # Step 4: Create GitHub release
+    - name: Create GitHub release
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ env.next_version }}
+        name: ${{ env.next_version }}
+        files: |
+          ./bin/Release/x86/NWNLogRotator-x86.exe
+          ./bin/Release/x64/NWNLogRotator-x64.exe
+        body: |
+          ## Changes
+          - Auto-generated release with x86 and x64 binaries.

--- a/App.config
+++ b/App.config
@@ -7,27 +7,27 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Xceed.Wpf.AvalonDock" publicKeyToken="3e4669d2f30244f4" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.7.0.0" newVersion="4.7.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Xceed.Wpf.AvalonDock.Themes.Aero" publicKeyToken="3e4669d2f30244f4" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.7.0.0" newVersion="4.7.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Xceed.Wpf.AvalonDock.Themes.Metro" publicKeyToken="3e4669d2f30244f4" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.7.0.0" newVersion="4.7.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Xceed.Wpf.AvalonDock.Themes.VS2010" publicKeyToken="3e4669d2f30244f4" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.7.0.0" newVersion="4.7.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Xceed.Wpf.Toolkit" publicKeyToken="3e4669d2f30244f4" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.7.0.0" newVersion="4.7.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Costura" publicKeyToken="9919ef960d84173d" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.1.0.0" newVersion="6.1.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/NWNLogRotator.csproj
+++ b/NWNLogRotator.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="packages\Costura.Fody.6.0.0\build\Costura.Fody.props" Condition="Exists('packages\Costura.Fody.6.0.0\build\Costura.Fody.props')" />
+  <Import Project="packages\Costura.Fody.6.1.0\build\Costura.Fody.props" Condition="Exists('packages\Costura.Fody.6.1.0\build\Costura.Fody.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -67,8 +67,8 @@
   <PropertyGroup />
   <PropertyGroup />
   <ItemGroup>
-    <Reference Include="Costura, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9919ef960d84173d">
-      <HintPath>packages\Costura.Fody.6.0.0\lib\netstandard2.0\Costura.dll</HintPath>
+    <Reference Include="Costura, Version=6.1.0.0, Culture=neutral, PublicKeyToken=9919ef960d84173d">
+      <HintPath>packages\Costura.Fody.6.1.0\lib\netstandard2.0\Costura.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -87,24 +87,24 @@
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="Xceed.Wpf.AvalonDock, Version=4.7.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4">
-      <HintPath>packages\Extended.Wpf.Toolkit.4.7.25104.5739\lib\net40\Xceed.Wpf.AvalonDock.dll</HintPath>
+    <Reference Include="Xceed.Wpf.AvalonDock, Version=5.0.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4">
+      <HintPath>packages\Extended.Wpf.Toolkit.5.0.0\lib\net40\Xceed.Wpf.AvalonDock.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Xceed.Wpf.AvalonDock.Themes.Aero, Version=4.7.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4">
-      <HintPath>packages\Extended.Wpf.Toolkit.4.7.25104.5739\lib\net40\Xceed.Wpf.AvalonDock.Themes.Aero.dll</HintPath>
+    <Reference Include="Xceed.Wpf.AvalonDock.Themes.Aero, Version=5.0.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4">
+      <HintPath>packages\Extended.Wpf.Toolkit.5.0.0\lib\net40\Xceed.Wpf.AvalonDock.Themes.Aero.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Xceed.Wpf.AvalonDock.Themes.Metro, Version=4.7.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4">
-      <HintPath>packages\Extended.Wpf.Toolkit.4.7.25104.5739\lib\net40\Xceed.Wpf.AvalonDock.Themes.Metro.dll</HintPath>
+    <Reference Include="Xceed.Wpf.AvalonDock.Themes.Metro, Version=5.0.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4">
+      <HintPath>packages\Extended.Wpf.Toolkit.5.0.0\lib\net40\Xceed.Wpf.AvalonDock.Themes.Metro.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Xceed.Wpf.AvalonDock.Themes.VS2010, Version=4.7.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4">
-      <HintPath>packages\Extended.Wpf.Toolkit.4.7.25104.5739\lib\net40\Xceed.Wpf.AvalonDock.Themes.VS2010.dll</HintPath>
+    <Reference Include="Xceed.Wpf.AvalonDock.Themes.VS2010, Version=5.0.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4">
+      <HintPath>packages\Extended.Wpf.Toolkit.5.0.0\lib\net40\Xceed.Wpf.AvalonDock.Themes.VS2010.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Xceed.Wpf.Toolkit, Version=4.7.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4">
-      <HintPath>packages\Extended.Wpf.Toolkit.4.7.25104.5739\lib\net40\Xceed.Wpf.Toolkit.dll</HintPath>
+    <Reference Include="Xceed.Wpf.Toolkit, Version=5.0.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4">
+      <HintPath>packages\Extended.Wpf.Toolkit.5.0.0\lib\net40\Xceed.Wpf.Toolkit.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -199,8 +199,8 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('packages\Fody.6.9.3\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Fody.6.9.3\build\Fody.targets'))" />
-    <Error Condition="!Exists('packages\Costura.Fody.6.0.0\build\Costura.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Costura.Fody.6.0.0\build\Costura.Fody.props'))" />
-    <Error Condition="!Exists('packages\Costura.Fody.6.0.0\build\Costura.Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Costura.Fody.6.0.0\build\Costura.Fody.targets'))" />
+    <Error Condition="!Exists('packages\Costura.Fody.6.1.0\build\Costura.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Costura.Fody.6.1.0\build\Costura.Fody.props'))" />
+    <Error Condition="!Exists('packages\Costura.Fody.6.1.0\build\Costura.Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Costura.Fody.6.1.0\build\Costura.Fody.targets'))" />
   </Target>
-  <Import Project="packages\Costura.Fody.6.0.0\build\Costura.Fody.targets" Condition="Exists('packages\Costura.Fody.6.0.0\build\Costura.Fody.targets')" />
+  <Import Project="packages\Costura.Fody.6.1.0\build\Costura.Fody.targets" Condition="Exists('packages\Costura.Fody.6.1.0\build\Costura.Fody.targets')" />
 </Project>

--- a/packages.config
+++ b/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Costura.Fody" version="6.0.0" targetFramework="net481" developmentDependency="true" />
-  <package id="Extended.Wpf.Toolkit" version="4.7.25104.5739" targetFramework="net481" />
+  <package id="Costura.Fody" version="6.1.0" targetFramework="net481" developmentDependency="true" />
+  <package id="Extended.Wpf.Toolkit" version="5.0.0" targetFramework="net481" />
   <package id="Fody" version="6.9.3" targetFramework="net481" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
## Summary
- split PR CI from release publishing: PRs now run only the build workflow
- add a separate master-push release workflow that builds x86/x64 artifacts and publishes the GitHub release
- bump Extended.Wpf.Toolkit to 5.0.0 and Costura.Fody to 6.1.0, including csproj paths and binding redirects
- update checkout and release actions to current runner-compatible major versions

## Validation
- actionlint .github/workflows/build-wpf-app.yml .github/workflows/release-wpf-app.yml
- xmllint --noout App.config NWNLogRotator.csproj packages.config
- nuget restore NWNLogRotator.sln
- dotnet msbuild NWNLogRotator.sln /p:Configuration=Release /p:Platform="x86" /nologo /v:minimal fails locally because this Linux environment lacks the .NET Framework 4.8.1 targeting pack; Windows CI should perform the full build

Refs #29, #30